### PR TITLE
Op basis van centos 7 vanwege PHP >=5.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM centos:7
 MAINTAINER Nick Hilhorst <nick.hilhorst@asr.nl>
 
 # We installeren alleen php en composer. Composer haalt runtime de andere dependencies op van packagist.org


### PR DESCRIPTION
Restler 3, and its dependencies, require PHP 5.4.0 or above.